### PR TITLE
Various bug fixes

### DIFF
--- a/src/main/java/com/github/hexomod/macro/Preprocessor.java
+++ b/src/main/java/com/github/hexomod/macro/Preprocessor.java
@@ -87,7 +87,7 @@ public class Preprocessor {
         String fileString = FileUtils.readFileToString(inFile, StandardCharsets.UTF_8);
         if (!known) {
             for (String slash : SLASH_KEYWORDS.values()) {
-                if (slash != "///" && fileString.contains(slash)) {
+                if (!"///".equals(slash) && fileString.contains(slash)) {
                     known = true;
                     keywords = SLASH_KEYWORDS;
                     break;
@@ -96,7 +96,7 @@ public class Preprocessor {
         }
         if (!known) {
             for (String slash : HASH_KEYWORDS.values()) {
-                if (slash != "###" && fileString.contains(slash)) {
+                if (!"###".equals(slash) && fileString.contains(slash)) {
                     known = true;
                     keywords = HASH_KEYWORDS;
                     break;
@@ -134,9 +134,10 @@ public class Preprocessor {
 
     List<String> processLines(List<String> lines, Map<String, String> keywords) throws ParserException {
         LinkedList<Boolean> state = new LinkedList<>();
+		// Used for tracking elseif trees
         LinkedList<Boolean> skips = new LinkedList<>();
         List<String> newLines = new ArrayList<>();
-        // By default the line is considered as active
+        // By default, the line is considered as active
         state.push(true);
         skips.push(false);
 
@@ -150,7 +151,7 @@ public class Preprocessor {
                 boolean active = this.vars.get(trimLine.substring(keywords.get("ifdef").length()).trim()) != null;
                 // Store the last active state
                 state.push(active & state.getFirst());
-                //
+                // Skip all further else statements
                 skips.push(active);
                 // Keep macro line
                 if (!remove) newLines.add(line);
@@ -161,71 +162,59 @@ public class Preprocessor {
                 boolean active = evaluateExpression(trimLine.substring(keywords.get("if").length()));
                 // Store the last active state
                 state.push(active & state.getFirst());
-                //
+				// Skip all further else statements
                 skips.push(active);
                 // Keep macro line
                 if (!remove) newLines.add(line);
             }
             // elseif
             else if (trimLine.startsWith(keywords.get("elseif"))) {
-                // get last skip
-                boolean skip = skips.getFirst();
-                //
-                if (!skip) {
-                    // get last active state
-                    boolean active = state.getFirst();
-                    // Evaluate elseif condition
-                    active = (!active) & evaluateExpression(trimLine.substring(keywords.get("elseif").length()));
-                    // Revert the last state
-                    state.pop();
-                    // Store the last active state
-                    state.push((active) & state.getFirst());
-                    //
-                    skips.pop();
-                    skips.push(skip & skips.getFirst());
-                } else {
-                    state.pop();
-                    state.push(false);
-                }
-                // Keep macro line
+				// Check for skip
+				if (skips.getFirst()) {
+					state.pop();
+					state.push(false);
+				} else {
+					// Get last active state
+					boolean active = state.getFirst();
+					// Evaluate elseif condition
+					active = (!active) & evaluateExpression(trimLine.substring(keywords.get("elseif").length()));
+					// Revert the last state
+					state.pop();
+					// Store the current active state
+					state.push((active) & state.getFirst());
+					skips.push(active);
+				}
+				// Keep macro line
                 if (!remove) newLines.add(line);
             }
             // else
             else if (trimLine.startsWith(keywords.get("else"))) {
-                // get last skip
-                boolean skip = skips.getFirst();
-                //
-                if (!skip) {
-                    // get last active state
-                    boolean active = state.getFirst();
-                    // Revert the last state
-                    state.pop();
-                    state.push((!active) & state.getFirst());
-                    //
-                    skips.pop();
-                    skips.push((!skip) & skips.getFirst());
-                } else {
-                    state.pop();
-                    state.push(false);
-                }
-                // Keep macro line
+                // check for skip
+				if (skips.getFirst()) {
+					state.pop();
+					state.push(false);
+				} else {
+					// get last active state
+					boolean active = state.getFirst();
+					// Revert the last state
+					state.pop();
+					state.push((!active) & state.getFirst());
+				}
+				// Keep macro line
                 if (!remove) newLines.add(line);
             }
             // endif
             else if (trimLine.startsWith(keywords.get("endif"))) {
-                // Enable
+                // Pop the states
                 state.pop();
-                //
                 skips.pop();
                 // Keep macro line
                 if (!remove) newLines.add(line);
             } else {
-                // get last active state
-                boolean active = state.getFirst();
-                //
-                if (active)
-                    newLines.add(uncommentLine(line, keywords));
-                else {
+                // get current active state
+                if (state.getFirst()) {
+					newLines.add(uncommentLine(line, keywords));
+				}else {
                     if (!remove) newLines.add(commentLine(line, keywords));
                 }
             }

--- a/src/main/java/com/github/hexomod/macro/Preprocessor.java
+++ b/src/main/java/com/github/hexomod/macro/Preprocessor.java
@@ -134,7 +134,7 @@ public class Preprocessor {
 
     List<String> processLines(List<String> lines, Map<String, String> keywords) throws ParserException {
         LinkedList<Boolean> state = new LinkedList<>();
-		// Used for tracking elseif trees
+        // Used for tracking elseif trees
         LinkedList<Boolean> skips = new LinkedList<>();
         List<String> newLines = new ArrayList<>();
         // By default, the line is considered as active
@@ -162,45 +162,45 @@ public class Preprocessor {
                 boolean active = evaluateExpression(trimLine.substring(keywords.get("if").length()));
                 // Store the last active state
                 state.push(active & state.getFirst());
-				// Skip all further else statements
+                // Skip all further else statements
                 skips.push(active);
                 // Keep macro line
                 if (!remove) newLines.add(line);
             }
             // elseif
             else if (trimLine.startsWith(keywords.get("elseif"))) {
-				// Check for skip
-				if (skips.getFirst()) {
-					state.pop();
-					state.push(false);
-				} else {
-					// Get last active state
-					boolean active = state.getFirst();
-					// Evaluate elseif condition
-					active = (!active) & evaluateExpression(trimLine.substring(keywords.get("elseif").length()));
-					// Revert the last state
-					state.pop();
-					// Store the current active state
-					state.push((active) & state.getFirst());
-					skips.push(active);
-				}
-				// Keep macro line
+                // Check for skip
+                if (skips.getFirst()) {
+                    state.pop();
+                    state.push(false);
+                } else {
+                    // Get last active state
+                    boolean active = state.getFirst();
+                    // Evaluate elseif condition
+                    active = (!active) & evaluateExpression(trimLine.substring(keywords.get("elseif").length()));
+                    // Revert the last state
+                    state.pop();
+                    // Store the current active state
+                    state.push((active) & state.getFirst());
+                    skips.push(active);
+                }
+                // Keep macro line
                 if (!remove) newLines.add(line);
             }
             // else
             else if (trimLine.startsWith(keywords.get("else"))) {
                 // check for skip
-				if (skips.getFirst()) {
-					state.pop();
-					state.push(false);
-				} else {
-					// get last active state
-					boolean active = state.getFirst();
-					// Revert the last state
-					state.pop();
-					state.push((!active) & state.getFirst());
-				}
-				// Keep macro line
+                if (skips.getFirst()) {
+                    state.pop();
+                    state.push(false);
+                } else {
+                    // get last active state
+                    boolean active = state.getFirst();
+                    // Revert the last state
+                    state.pop();
+                    state.push((!active) & state.getFirst());
+                }
+                // Keep macro line
                 if (!remove) newLines.add(line);
             }
             // endif
@@ -213,8 +213,8 @@ public class Preprocessor {
             } else {
                 // get current active state
                 if (state.getFirst()) {
-					newLines.add(uncommentLine(line, keywords));
-				}else {
+                    newLines.add(uncommentLine(line, keywords));
+                } else {
                     if (!remove) newLines.add(commentLine(line, keywords));
                 }
             }

--- a/src/main/java/com/github/hexomod/macro/Preprocessor.java
+++ b/src/main/java/com/github/hexomod/macro/Preprocessor.java
@@ -59,8 +59,11 @@ public class Preprocessor {
     static Map<String, Map<String, String>> EXTENSION_KEYWORDS = new HashMap<String, Map<String, String>>() {{
         put("java", SLASH_KEYWORDS);
         put("gradle", SLASH_KEYWORDS);
+		put("hjson", SLASH_KEYWORDS);
+		put("json5", SLASH_KEYWORDS);
         put("yaml", HASH_KEYWORDS);
         put("yml", HASH_KEYWORDS);
+		put("toml", HASH_KEYWORDS);
     }};
 
     private final Map<String, Object> vars;

--- a/src/main/java/com/github/hexomod/macro/PreprocessorExtension.java
+++ b/src/main/java/com/github/hexomod/macro/PreprocessorExtension.java
@@ -30,6 +30,7 @@ import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.tasks.Internal;
 import org.gradle.internal.Actions;
 import org.gradle.util.ConfigureUtil;
 
@@ -97,19 +98,35 @@ public class PreprocessorExtension extends SourceType {
         return this.vars;
     }
 
+    /**
+     * Sets the preprocessor variables.
+     * @param vars the variables
+     */
     public void setVars(Map<String, Object> vars) {
         this.vars.putAll(vars);
     }
 
 
+    /**
+     * Returns the directory where preprocessed files will be stored.
+     * @return the directory where preprocessed files will be stored.
+     */
     public File getProcessDir() {
         return processDir;
     }
 
+    /**
+     * Sets the directory where preprocessed files will be stored.
+     * @param processDir the directory
+     */
     public void setProcessDir(File processDir) {
         this.processDir = processDir;
     }
 
+    /**
+     * Sets the directory where preprocessed files will be stored.
+     * @param processDir the directory, relative to the project build directory
+     */
     public void setProcessDir(String processDir) {
         String buildName = this.project.getBuildDir().getName();
         if (processDir.startsWith(buildName)) {
@@ -119,11 +136,18 @@ public class PreprocessorExtension extends SourceType {
         }
     }
 
-
+    /**
+     * Returns whether verbose logging to console is enabled.
+     * @return whether verbose logging to console is enabled.
+     */
     public boolean getVerbose() {
         return verbose;
     }
 
+    /**
+     * Sets the verbose logging mode.
+     * @param verbose whether to enable verbose mode
+     */
     public void setVerbose(boolean verbose) {
         this.verbose = verbose;
     }
@@ -133,10 +157,20 @@ public class PreprocessorExtension extends SourceType {
         return java;
     }
 
+    /**
+     * Configure how to process java files.
+     * @param closure the configuration closure
+     * @return the configuration object
+     */
     public Java java(Closure closure) {
         return ConfigureUtil.configure(closure, java);
     }
 
+    /**
+     * Configure how to process java files.
+     * @param action the configuration action
+     * @return the configuration object
+     */
     public Java java(Action<? super Java> action) {
         return Actions.with(java, action);
     }
@@ -146,15 +180,25 @@ public class PreprocessorExtension extends SourceType {
         return resources;
     }
 
+    /**
+     * Configure how to process resources files.
+     * @param closure the configuration closure
+     * @return the configuration object
+     */
     public Resources resources(Closure closure) {
         return ConfigureUtil.configure(closure, resources);
     }
 
+    /**
+     * Configure how to process resources files.
+     * @param action the configuration action
+     * @return the configuration object
+     */
     public Resources resources(Action<? super Resources> action) {
         return Actions.with(resources, action);
     }
 
-
+    @Internal
     // Print out a string if verbose is enabled
     public void log(String msg) {
         if (getVerbose()) {

--- a/src/main/java/com/github/hexomod/macro/extensions/SourceType.java
+++ b/src/main/java/com/github/hexomod/macro/extensions/SourceType.java
@@ -36,26 +36,52 @@ public abstract class SourceType {
         remove = false;
     }
 
+    /**
+     * Returns whether this source type is enabled.
+     * @return whether this source type is enabled.
+     */
     public boolean getEnable() {
         return enable;
     }
 
+    /**
+     * Sets whether the preprocessor is enabled for this source type.
+     * @param enable Whether this source type is enabled.
+     */
     public void setEnable(boolean enable) {
         this.enable = enable;
     }
 
+    /**
+     * Returns whether changes are made in-place.
+     * @return Whether changes are made in-place.
+     */
     public boolean getInPlace() {
         return inPlace;
     }
 
+    /**
+     * Sets whether the preprocessor changes should be made in-place.
+     * That means that the changes will be applied directly to the source files.
+     * The latter is especially useful for development on Java source files.
+     * @param inPlace Whether the preprocessor should be applied in-place.
+     */
     public void setInPlace(boolean inPlace) {
         this.inPlace = inPlace;
     }
 
+    /**
+     * Returns whether preprocessor statements shall be removed.
+     * @return Whether preprocessor statements shall be removed.
+     */
     public boolean getRemove() {
         return remove;
     }
 
+    /**
+     * Sets whether preprocessor statements shall be removed.
+     * @param remove Whether preprocessor statements shall be removed.
+     */
     public void setRemove(boolean remove) {
         this.remove = remove;
     }

--- a/src/test/java/com/github/hexomod/macro/PreprocessorTest.java
+++ b/src/test/java/com/github/hexomod/macro/PreprocessorTest.java
@@ -278,8 +278,35 @@ public class PreprocessorTest {
         assertFalse(lines.get(5).compareTo(preprocessor.commentLine(testLine, SLASH_KEYWORDS))==0);
     }
 
-    @Test
-    public void processLines_complex_elseif_t_f_f() {
+	@Test
+	public void processLines_simple_elseif_f_t_f_f() {
+		String testLine0 = "String message = '0';";
+		String testLine1 = "String message = '1';";
+		String testLine2 = "String message = '2';";
+		String testLine = "String message = '';";
+
+		List<String> lines = new ArrayList<>();
+		lines.add("//#if VAR_INT>100");            // false
+		lines.add(testLine0);
+		lines.add("//#elseif VAR_INT<10");         // true
+		lines.add(testLine1);
+		lines.add("//#elseif VAR_BOOL");           // false (but condition true)
+		lines.add(testLine2);
+		lines.add("//#else");
+		lines.add(testLine);
+		lines.add("//#endif");
+
+		Preprocessor preprocessor = new Preprocessor(vars);
+		lines = preprocessor.processLines(lines, SLASH_KEYWORDS);
+
+		assertEquals(preprocessor.commentLine(testLine0, SLASH_KEYWORDS), lines.get(1));
+		assertEquals(testLine1, lines.get(3));
+		assertEquals(preprocessor.commentLine(testLine2, SLASH_KEYWORDS), lines.get(5));
+		assertEquals(preprocessor.commentLine(testLine, SLASH_KEYWORDS), lines.get(7));
+	}
+
+	@Test
+	public void processLines_complex_elseif_t_f_f() {
 
         String testLine0 = "String message = '0';";
         String testLine1 = "String message = '1';";

--- a/src/test/java/com/github/hexomod/macro/PreprocessorTest.java
+++ b/src/test/java/com/github/hexomod/macro/PreprocessorTest.java
@@ -125,8 +125,8 @@ public class PreprocessorTest {
         Preprocessor preprocessor = new Preprocessor(vars);
         lines = preprocessor.processLines(lines, SLASH_KEYWORDS);
 
-        assertTrue(lines.get(1).compareTo(preprocessor.uncommentLine(testLine, SLASH_KEYWORDS))==0);
-        assertFalse(lines.get(1).compareTo(preprocessor.commentLine(testLine, SLASH_KEYWORDS))==0);
+        assertEquals(preprocessor.uncommentLine(testLine, SLASH_KEYWORDS), lines.get(1));
+        assertNotEquals(preprocessor.commentLine(testLine, SLASH_KEYWORDS), lines.get(1));
     }
 
     @Test
@@ -142,8 +142,8 @@ public class PreprocessorTest {
         Preprocessor preprocessor = new Preprocessor(vars);
         lines = preprocessor.processLines(lines, SLASH_KEYWORDS);
 
-        assertFalse(lines.get(1).compareTo(preprocessor.uncommentLine(testLine, SLASH_KEYWORDS))==0);
-        assertTrue(lines.get(1).compareTo(preprocessor.commentLine(testLine, SLASH_KEYWORDS))==0);
+        assertNotEquals(preprocessor.uncommentLine(testLine, SLASH_KEYWORDS), lines.get(1));
+        assertEquals(preprocessor.commentLine(testLine, SLASH_KEYWORDS), lines.get(1));
     }
 
     @Test
@@ -163,11 +163,11 @@ public class PreprocessorTest {
         Preprocessor preprocessor = new Preprocessor(vars);
         lines = preprocessor.processLines(lines, SLASH_KEYWORDS);
 
-        assertTrue(lines.get(1).compareTo(preprocessor.uncommentLine(testLine1, SLASH_KEYWORDS))==0);
-        assertFalse(lines.get(1).compareTo(preprocessor.commentLine(testLine1, SLASH_KEYWORDS))==0);
+        assertEquals(preprocessor.uncommentLine(testLine1, SLASH_KEYWORDS), lines.get(1));
+        assertNotEquals(preprocessor.commentLine(testLine1, SLASH_KEYWORDS), lines.get(1));
 
-        assertTrue(lines.get(3).compareTo(preprocessor.uncommentLine(testLine2, SLASH_KEYWORDS))==0);
-        assertFalse(lines.get(3).compareTo(preprocessor.commentLine(testLine2, SLASH_KEYWORDS))==0);
+        assertEquals(preprocessor.uncommentLine(testLine2, SLASH_KEYWORDS), lines.get(3));
+        assertNotEquals(preprocessor.commentLine(testLine2, SLASH_KEYWORDS), lines.get(3));
     }
 
     @Test
@@ -187,11 +187,11 @@ public class PreprocessorTest {
         Preprocessor preprocessor = new Preprocessor(vars);
         lines = preprocessor.processLines(lines, SLASH_KEYWORDS);
 
-        assertTrue(lines.get(1).compareTo(preprocessor.uncommentLine(testLine1, SLASH_KEYWORDS))==0);
-        assertFalse(lines.get(3).compareTo(preprocessor.uncommentLine(testLine2, SLASH_KEYWORDS))==0);
+        assertEquals(preprocessor.uncommentLine(testLine1, SLASH_KEYWORDS), lines.get(1));
+        assertNotEquals(preprocessor.uncommentLine(testLine2, SLASH_KEYWORDS), lines.get(3));
 
-        assertFalse(lines.get(1).compareTo(preprocessor.commentLine(testLine1, SLASH_KEYWORDS))==0);
-        assertTrue(lines.get(3).compareTo(preprocessor.commentLine(testLine2, SLASH_KEYWORDS))==0);
+        assertNotEquals(preprocessor.commentLine(testLine1, SLASH_KEYWORDS), lines.get(1));
+        assertEquals(preprocessor.commentLine(testLine2, SLASH_KEYWORDS), lines.get(3));
     }
 
     @Test
@@ -213,13 +213,13 @@ public class PreprocessorTest {
         Preprocessor preprocessor = new Preprocessor(vars);
         lines = preprocessor.processLines(lines, SLASH_KEYWORDS);
 
-        assertTrue(lines.get(1).compareTo(preprocessor.uncommentLine(testLine0, SLASH_KEYWORDS))==0);
-        assertFalse(lines.get(3).compareTo(preprocessor.uncommentLine(testLine1, SLASH_KEYWORDS))==0);
-        assertFalse(lines.get(5).compareTo(preprocessor.uncommentLine(testLine, SLASH_KEYWORDS))==0);
+        assertEquals(preprocessor.uncommentLine(testLine0, SLASH_KEYWORDS), lines.get(1));
+        assertNotEquals(preprocessor.uncommentLine(testLine1, SLASH_KEYWORDS), lines.get(3));
+        assertNotEquals(preprocessor.uncommentLine(testLine, SLASH_KEYWORDS), lines.get(5));
 
-        assertFalse(lines.get(1).compareTo(preprocessor.commentLine(testLine0, SLASH_KEYWORDS))==0);
-        assertTrue(lines.get(3).compareTo(preprocessor.commentLine(testLine1, SLASH_KEYWORDS))==0);
-        assertTrue(lines.get(5).compareTo(preprocessor.commentLine(testLine, SLASH_KEYWORDS))==0);
+        assertNotEquals(preprocessor.commentLine(testLine0, SLASH_KEYWORDS), lines.get(1));
+        assertEquals(preprocessor.commentLine(testLine1, SLASH_KEYWORDS), lines.get(3));
+        assertEquals(preprocessor.commentLine(testLine, SLASH_KEYWORDS), lines.get(5));
     }
 
     @Test
@@ -241,13 +241,13 @@ public class PreprocessorTest {
         Preprocessor preprocessor = new Preprocessor(vars);
         lines = preprocessor.processLines(lines, SLASH_KEYWORDS);
 
-        assertFalse(lines.get(1).compareTo(preprocessor.uncommentLine(testLine0, SLASH_KEYWORDS))==0);
-        assertTrue(lines.get(3).compareTo(preprocessor.uncommentLine(testLine1, SLASH_KEYWORDS))==0);
-        assertFalse(lines.get(5).compareTo(preprocessor.uncommentLine(testLine, SLASH_KEYWORDS))==0);
+        assertNotEquals(preprocessor.uncommentLine(testLine0, SLASH_KEYWORDS), lines.get(1));
+        assertEquals(preprocessor.uncommentLine(testLine1, SLASH_KEYWORDS), lines.get(3));
+        assertNotEquals(preprocessor.uncommentLine(testLine, SLASH_KEYWORDS), lines.get(5));
 
-        assertTrue(lines.get(1).compareTo(preprocessor.commentLine(testLine0, SLASH_KEYWORDS))==0);
-        assertFalse(lines.get(3).compareTo(preprocessor.commentLine(testLine1, SLASH_KEYWORDS))==0);
-        assertTrue(lines.get(5).compareTo(preprocessor.commentLine(testLine, SLASH_KEYWORDS))==0);
+        assertEquals(preprocessor.commentLine(testLine0, SLASH_KEYWORDS), lines.get(1));
+        assertNotEquals(preprocessor.commentLine(testLine1, SLASH_KEYWORDS), lines.get(3));
+        assertEquals(preprocessor.commentLine(testLine, SLASH_KEYWORDS), lines.get(5));
     }
 
     @Test
@@ -269,13 +269,13 @@ public class PreprocessorTest {
         Preprocessor preprocessor = new Preprocessor(vars);
         lines = preprocessor.processLines(lines, SLASH_KEYWORDS);
 
-        assertFalse(lines.get(1).compareTo(preprocessor.uncommentLine(testLine0, SLASH_KEYWORDS))==0);
-        assertFalse(lines.get(3).compareTo(preprocessor.uncommentLine(testLine1, SLASH_KEYWORDS))==0);
-        assertTrue(lines.get(5).compareTo(preprocessor.uncommentLine(testLine, SLASH_KEYWORDS))==0);
+        assertNotEquals(preprocessor.uncommentLine(testLine0, SLASH_KEYWORDS), lines.get(1));
+        assertNotEquals(preprocessor.uncommentLine(testLine1, SLASH_KEYWORDS), lines.get(3));
+        assertEquals(preprocessor.uncommentLine(testLine, SLASH_KEYWORDS), lines.get(5));
 
-        assertTrue(lines.get(1).compareTo(preprocessor.commentLine(testLine0, SLASH_KEYWORDS))==0);
-        assertTrue(lines.get(3).compareTo(preprocessor.commentLine(testLine1, SLASH_KEYWORDS))==0);
-        assertFalse(lines.get(5).compareTo(preprocessor.commentLine(testLine, SLASH_KEYWORDS))==0);
+        assertEquals(preprocessor.commentLine(testLine0, SLASH_KEYWORDS), lines.get(1));
+        assertEquals(preprocessor.commentLine(testLine1, SLASH_KEYWORDS), lines.get(3));
+        assertNotEquals(preprocessor.commentLine(testLine, SLASH_KEYWORDS), lines.get(5));
     }
 
 	@Test
@@ -334,19 +334,19 @@ public class PreprocessorTest {
         Preprocessor preprocessor = new Preprocessor(vars);
         lines = preprocessor.processLines(lines, SLASH_KEYWORDS);
 
-        assertTrue(lines.get(1).compareTo(preprocessor.uncommentLine(testLine0, SLASH_KEYWORDS))==0);
-        assertTrue(lines.get(3).compareTo(preprocessor.uncommentLine(testLine1, SLASH_KEYWORDS))==0);
-        assertFalse(lines.get(5).compareTo(preprocessor.uncommentLine(testLine2, SLASH_KEYWORDS))==0);
-        assertFalse(lines.get(7).compareTo(preprocessor.uncommentLine(testLine3, SLASH_KEYWORDS))==0);
-        assertFalse(lines.get(10).compareTo(preprocessor.uncommentLine(testLine4, SLASH_KEYWORDS))==0);
-        assertFalse(lines.get(12).compareTo(preprocessor.uncommentLine(testLine, SLASH_KEYWORDS))==0);
+        assertEquals(preprocessor.uncommentLine(testLine0, SLASH_KEYWORDS), lines.get(1));
+        assertEquals(preprocessor.uncommentLine(testLine1, SLASH_KEYWORDS), lines.get(3));
+        assertNotEquals(preprocessor.uncommentLine(testLine2, SLASH_KEYWORDS), lines.get(5));
+        assertNotEquals(preprocessor.uncommentLine(testLine3, SLASH_KEYWORDS), lines.get(7));
+        assertNotEquals(preprocessor.uncommentLine(testLine4, SLASH_KEYWORDS), lines.get(10));
+        assertNotEquals(preprocessor.uncommentLine(testLine, SLASH_KEYWORDS), lines.get(12));
 
-        assertFalse(lines.get(1).compareTo(preprocessor.commentLine(testLine0, SLASH_KEYWORDS))==0);
-        assertFalse(lines.get(3).compareTo(preprocessor.commentLine(testLine1, SLASH_KEYWORDS))==0);
-        assertTrue(lines.get(5).compareTo(preprocessor.commentLine(testLine2, SLASH_KEYWORDS))==0);
-        assertTrue(lines.get(7).compareTo(preprocessor.commentLine(testLine3, SLASH_KEYWORDS))==0);
-        assertTrue(lines.get(10).compareTo(preprocessor.commentLine(testLine4, SLASH_KEYWORDS))==0);
-        assertTrue(lines.get(12).compareTo(preprocessor.commentLine(testLine, SLASH_KEYWORDS))==0);
+        assertNotEquals(preprocessor.commentLine(testLine0, SLASH_KEYWORDS), lines.get(1));
+        assertNotEquals(preprocessor.commentLine(testLine1, SLASH_KEYWORDS), lines.get(3));
+        assertEquals(preprocessor.commentLine(testLine2, SLASH_KEYWORDS), lines.get(5));
+        assertEquals(preprocessor.commentLine(testLine3, SLASH_KEYWORDS), lines.get(7));
+        assertEquals(preprocessor.commentLine(testLine4, SLASH_KEYWORDS), lines.get(10));
+        assertEquals(preprocessor.commentLine(testLine, SLASH_KEYWORDS), lines.get(12));
     }
 
     @Test
@@ -378,19 +378,19 @@ public class PreprocessorTest {
         Preprocessor preprocessor = new Preprocessor(vars);
         lines = preprocessor.processLines(lines, SLASH_KEYWORDS);
 
-        assertFalse(lines.get(1).compareTo(preprocessor.uncommentLine(testLine0, SLASH_KEYWORDS))==0);
-        assertFalse(lines.get(3).compareTo(preprocessor.uncommentLine(testLine1, SLASH_KEYWORDS))==0);
-        assertFalse(lines.get(5).compareTo(preprocessor.uncommentLine(testLine2, SLASH_KEYWORDS))==0);
-        assertFalse(lines.get(7).compareTo(preprocessor.uncommentLine(testLine3, SLASH_KEYWORDS))==0);
-        assertTrue(lines.get(10).compareTo(preprocessor.uncommentLine(testLine4, SLASH_KEYWORDS))==0);
-        assertFalse(lines.get(12).compareTo(preprocessor.uncommentLine(testLine, SLASH_KEYWORDS))==0);
+        assertNotEquals(preprocessor.uncommentLine(testLine0, SLASH_KEYWORDS), lines.get(1));
+        assertNotEquals(preprocessor.uncommentLine(testLine1, SLASH_KEYWORDS), lines.get(3));
+        assertNotEquals(preprocessor.uncommentLine(testLine2, SLASH_KEYWORDS), lines.get(5));
+        assertNotEquals(preprocessor.uncommentLine(testLine3, SLASH_KEYWORDS), lines.get(7));
+        assertEquals(preprocessor.uncommentLine(testLine4, SLASH_KEYWORDS), lines.get(10));
+        assertNotEquals(preprocessor.uncommentLine(testLine, SLASH_KEYWORDS), lines.get(12));
 
-        assertTrue(lines.get(1).compareTo(preprocessor.commentLine(testLine0, SLASH_KEYWORDS))==0);
-        assertTrue(lines.get(3).compareTo(preprocessor.commentLine(testLine1, SLASH_KEYWORDS))==0);
-        assertTrue(lines.get(5).compareTo(preprocessor.commentLine(testLine2, SLASH_KEYWORDS))==0);
-        assertTrue(lines.get(7).compareTo(preprocessor.commentLine(testLine3, SLASH_KEYWORDS))==0);
-        assertFalse(lines.get(10).compareTo(preprocessor.commentLine(testLine4, SLASH_KEYWORDS))==0);
-        assertTrue(lines.get(12).compareTo(preprocessor.commentLine(testLine, SLASH_KEYWORDS))==0);
+        assertEquals(preprocessor.commentLine(testLine0, SLASH_KEYWORDS), lines.get(1));
+        assertEquals(preprocessor.commentLine(testLine1, SLASH_KEYWORDS), lines.get(3));
+        assertEquals(preprocessor.commentLine(testLine2, SLASH_KEYWORDS), lines.get(5));
+        assertEquals(preprocessor.commentLine(testLine3, SLASH_KEYWORDS), lines.get(7));
+        assertNotEquals(preprocessor.commentLine(testLine4, SLASH_KEYWORDS), lines.get(10));
+        assertEquals(preprocessor.commentLine(testLine, SLASH_KEYWORDS), lines.get(12));
     }
 
     @Test
@@ -422,19 +422,19 @@ public class PreprocessorTest {
         Preprocessor preprocessor = new Preprocessor(vars);
         lines = preprocessor.processLines(lines, SLASH_KEYWORDS);
 
-        assertFalse(lines.get(1).compareTo(preprocessor.uncommentLine(testLine0, SLASH_KEYWORDS))==0);
-        assertFalse(lines.get(3).compareTo(preprocessor.uncommentLine(testLine1, SLASH_KEYWORDS))==0);
-        assertTrue(lines.get(5).compareTo(preprocessor.uncommentLine(testLine2, SLASH_KEYWORDS))==0);
-        assertFalse(lines.get(7).compareTo(preprocessor.uncommentLine(testLine3, SLASH_KEYWORDS))==0);
-        assertFalse(lines.get(9).compareTo(preprocessor.uncommentLine(testLine4, SLASH_KEYWORDS))==0);
-        assertTrue(lines.get(11).compareTo(preprocessor.uncommentLine(testLine, SLASH_KEYWORDS))==0);
+        assertNotEquals(preprocessor.uncommentLine(testLine0, SLASH_KEYWORDS), lines.get(1));
+        assertNotEquals(preprocessor.uncommentLine(testLine1, SLASH_KEYWORDS), lines.get(3));
+        assertEquals(preprocessor.uncommentLine(testLine2, SLASH_KEYWORDS), lines.get(5));
+        assertNotEquals(preprocessor.uncommentLine(testLine3, SLASH_KEYWORDS), lines.get(7));
+        assertNotEquals(preprocessor.uncommentLine(testLine4, SLASH_KEYWORDS), lines.get(9));
+        assertEquals(preprocessor.uncommentLine(testLine, SLASH_KEYWORDS), lines.get(11));
 
-        assertTrue(lines.get(1).compareTo(preprocessor.commentLine(testLine0, SLASH_KEYWORDS))==0);
-        assertTrue(lines.get(3).compareTo(preprocessor.commentLine(testLine1, SLASH_KEYWORDS))==0);
-        assertFalse(lines.get(5).compareTo(preprocessor.commentLine(testLine2, SLASH_KEYWORDS))==0);
-        assertTrue(lines.get(7).compareTo(preprocessor.commentLine(testLine3, SLASH_KEYWORDS))==0);
-        assertTrue(lines.get(9).compareTo(preprocessor.commentLine(testLine4, SLASH_KEYWORDS))==0);
-        assertFalse(lines.get(11).compareTo(preprocessor.commentLine(testLine, SLASH_KEYWORDS))==0);
+        assertEquals(preprocessor.commentLine(testLine0, SLASH_KEYWORDS), lines.get(1));
+        assertEquals(preprocessor.commentLine(testLine1, SLASH_KEYWORDS), lines.get(3));
+        assertNotEquals(preprocessor.commentLine(testLine2, SLASH_KEYWORDS), lines.get(5));
+        assertEquals(preprocessor.commentLine(testLine3, SLASH_KEYWORDS), lines.get(7));
+        assertEquals(preprocessor.commentLine(testLine4, SLASH_KEYWORDS), lines.get(9));
+        assertNotEquals(preprocessor.commentLine(testLine, SLASH_KEYWORDS), lines.get(11));
     }
 
     @Test
@@ -459,12 +459,12 @@ public class PreprocessorTest {
         Preprocessor preprocessor = new Preprocessor(vars);
         lines = preprocessor.processLines(lines, SLASH_KEYWORDS);
 
-        assertTrue(lines.get(2).compareTo(preprocessor.uncommentLine(testLine0, SLASH_KEYWORDS))==0);
-        assertFalse(lines.get(4).compareTo(preprocessor.uncommentLine(testLine1, SLASH_KEYWORDS))==0);
-        assertFalse(lines.get(6).compareTo(preprocessor.uncommentLine(testLine, SLASH_KEYWORDS))==0);
+        assertEquals(preprocessor.uncommentLine(testLine0, SLASH_KEYWORDS), lines.get(2));
+        assertNotEquals(preprocessor.uncommentLine(testLine1, SLASH_KEYWORDS), lines.get(4));
+        assertNotEquals(preprocessor.uncommentLine(testLine, SLASH_KEYWORDS), lines.get(6));
 
-        assertFalse(lines.get(2).compareTo(preprocessor.commentLine(testLine0, SLASH_KEYWORDS))==0);
-        assertTrue(lines.get(4).compareTo(preprocessor.commentLine(testLine1, SLASH_KEYWORDS))==0);
-        assertTrue(lines.get(6).compareTo(preprocessor.commentLine(testLine, SLASH_KEYWORDS))==0);
+        assertNotEquals(preprocessor.commentLine(testLine0, SLASH_KEYWORDS), lines.get(2));
+        assertEquals(preprocessor.commentLine(testLine1, SLASH_KEYWORDS), lines.get(4));
+        assertEquals(preprocessor.commentLine(testLine, SLASH_KEYWORDS), lines.get(6));
     }
 }


### PR DESCRIPTION
This wraps up various small-ish fixes and improvements:

- Fix incorrect handling of elseif trees (later successful elseifs wouldn't trigger skipping)
- Add a test case for that
- Fix incorrect string comparison
- Replace `assertTrue(a.compareTo(b) == 0)` (`assertFalse`) with `assertEquals(b, a)` (`assertNotEquals`)
- Improve some comments